### PR TITLE
Respect guild sync_names flag when adding/updating user

### DIFF
--- a/aadiscordmultiverse/managers.py
+++ b/aadiscordmultiverse/managers.py
@@ -141,7 +141,12 @@ class MultiDiscordUserManager(models.Manager):
         """
         try:
             # TODO pull the guild config and confirm perms and settings
-            nickname = self.user_formatted_nick(user, guild)
+
+            if guild.sync_names:
+                nickname = self.user_formatted_nick(user, guild)
+            else:
+                nickname = None
+
             group_names = self.user_group_names(
                 user=user,
                 groups_included=guild.get_all_roles_to_sync(),

--- a/aadiscordmultiverse/models.py
+++ b/aadiscordmultiverse/models.py
@@ -162,7 +162,7 @@ class MultiDiscordUser(models.Model):
         - False on error or raises exception
         """
         
-        if self.guild.sync_names:
+        if not self.guild.sync_names:
             logger.info('Not updating nickname for user %s due to guild configuration', self.user)
             return True
         

--- a/aadiscordmultiverse/models.py
+++ b/aadiscordmultiverse/models.py
@@ -161,6 +161,11 @@ class MultiDiscordUser(models.Model):
         - None if user is no longer a member of the Discord server
         - False on error or raises exception
         """
+        
+        if self.guild.sync_names:
+            logger.info('Not updating nickname for user %s due to guild configuration', self.user)
+            return True
+        
         if not nickname:
             nickname = MultiDiscordUser.objects.user_formatted_nick(
                 self.user, self.guild)


### PR DESCRIPTION
This should cover all situations where a user's nickname would be changed by DMV.