### PR TITLE
Handle missing optional filters

### DIFF
--- a/aadiscordmultiverse/managers.py
+++ b/aadiscordmultiverse/managers.py
@@ -58,31 +58,40 @@ class DiscordManagedServerQuerySet(models.QuerySet):
                 )
             )
             # Corp access
-            queries.append(
-                models.Q(
-                    corporation_access=EveCorporationInfo.objects.get(
-                        corporation_id=main_character.corporation_id
+            try:
+                queries.append(
+                    models.Q(
+                        corporation_access=EveCorporationInfo.objects.get(
+                            corporation_id=main_character.corporation_id
+                        )
                     )
                 )
-            )
+            except EveCorporationInfo.DoesNotExist:
+                pass
             # Alliance access if part of an alliance
-            if main_character.alliance_id:
-                queries.append(
-                    models.Q(
-                        alliance_access=EveAllianceInfo.objects.get(
-                            alliance_id=main_character.alliance_id
+            try:
+                if main_character.alliance_id:
+                    queries.append(
+                        models.Q(
+                            alliance_access=EveAllianceInfo.objects.get(
+                                alliance_id=main_character.alliance_id
+                            )
                         )
                     )
-                )
+            except EveAllianceInfo.DoesNotExist:
+                pass
             # Faction access if part of a faction
-            if main_character.faction_id:
-                queries.append(
-                    models.Q(
-                        faction_access=EveFactionInfo.objects.get(
-                            faction_id=main_character.faction_id
+            try:
+                if main_character.faction_id:
+                    queries.append(
+                        models.Q(
+                            faction_access=EveFactionInfo.objects.get(
+                                faction_id=main_character.faction_id
+                            )
                         )
                     )
-                )
+            except EveFactionInfo.DoesNotExist:
+                pass
 
             logger.debug(
                 f"{len(queries)} queries for {main_character}'s visible characters.")


### PR DESCRIPTION
Resolves #1 and related bugs with EveCorporationInfo and EveFactionInfo filters by catching and discarding the exception generated when a given model has not been populated.