### PR TITLE
Removes non unique namespace warning

### DIFF
--- a/aadiscordmultiverse/auth_hooks.py
+++ b/aadiscordmultiverse/auth_hooks.py
@@ -13,7 +13,6 @@ from allianceauth.services.hooks import ServicesHook, UrlHook
 
 from . import tasks, urls
 from .models import DiscordManagedServer, MultiDiscordUser, ServerActiveFilter
-from .urls import urlpatterns
 from .utils import LoggerAddTag
 
 logger = logging.getLogger(__name__)
@@ -31,7 +30,6 @@ class MultiDiscordService(ServicesHook):
 
     def __init__(self):
         ServicesHook.__init__(self)
-        self.urlpatterns = urlpatterns
         if hasattr(self, "guild_id"):
             self.name = f'dmv:{self.guild_name if self.guild_name else self.guild_id}'
         else:
@@ -198,6 +196,10 @@ def add_del_callback(*args, **kwargs):
 
 post_save.connect(add_del_callback, sender=DiscordManagedServer)
 post_delete.connect(add_del_callback, sender=DiscordManagedServer)
+
+@hooks.register("url_hook")
+def register_urls():
+    return UrlHook(urls, "dmv", r"^dmv/")
 
 @hooks.register("secure_group_filters")
 def filters():

--- a/aadiscordmultiverse/urls.py
+++ b/aadiscordmultiverse/urls.py
@@ -4,7 +4,7 @@ from . import views
 
 app_name = 'dmv'
 
-module_urls = [
+urlpatterns = [
     # Discord Service Control
     re_path(r'deactivate/(?P<guild_id>(\d)*)',
             views.deactivate_discord, name='deactivate'),
@@ -13,8 +13,4 @@ module_urls = [
     re_path(r'reset/(?P<guild_id>(\d)*)', views.reset_discord, name='reset'),
     path('callback/', views.discord_callback, name='callback'),
     path('add_bot/', views.discord_add_bot, name='add_bot'),
-]
-
-urlpatterns = [
-    path('dmv/', include((module_urls, app_name), namespace=app_name))
 ]


### PR DESCRIPTION
When several services were registered each of them defined the 'dmv' namespace which raised a warning:

```
WARNINGS:
?: (urls.W005) URL namespace 'dmv' isn't unique. You may not be able to reverse all URLs in this namespace
```

Since the namespace is now defined once on the module level it might also remove the need to restart the auth after definning the first managed server?